### PR TITLE
Experimental concurrency support

### DIFF
--- a/cache_to_disk/__init__.py
+++ b/cache_to_disk/__init__.py
@@ -30,23 +30,29 @@ Modifications:
         - Expansion of shell variables and tilde-user values for directories/files
 """
 # Standard Library
+import fcntl
 import json
 import logging
 import os
 import pickle
 import warnings
 from collections import namedtuple
+from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime
 from os import getenv
 from os.path import (
     dirname,
     exists as file_exists,
-    expanduser, expandvars, getmtime,
+    expanduser,
+    expandvars,
+    getmtime,
     isfile,
     join as join_path,
-    realpath)
-
+    realpath,
+)
+from time import sleep
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 logger = logging.getLogger(__name__)
 
@@ -54,24 +60,37 @@ if logger.handlers is None:
     # Don't log unless user explicitly adds a handler
     logger.addHandler(logging.NullHandler())
 
-MAX_PICKLE_BYTES = 2 ** 31 - 1
-DISK_CACHE_DIR = expanduser(expandvars(
-    getenv('DISK_CACHE_DIR', join_path(dirname(realpath(__file__)), 'disk_cache'))))
-DISK_CACHE_FILE = expanduser(expandvars(join_path(
-    DISK_CACHE_DIR, getenv('DISK_CACHE_FILENAME', 'cache_to_disk_caches.json'))))
+MAX_PICKLE_BYTES = 2**31 - 1
+DISK_CACHE_DIR = expanduser(
+    expandvars(
+        getenv("DISK_CACHE_DIR", join_path(dirname(realpath(__file__)), "disk_cache"))
+    )
+)
+DISK_CACHE_FILE = expanduser(
+    expandvars(
+        join_path(
+            DISK_CACHE_DIR, getenv("DISK_CACHE_FILENAME", "cache_to_disk_caches.json")
+        )
+    )
+)
+DISK_CACHE_FILE_LOCK = "{}.lock".format(DISK_CACHE_FILE)
+
+# By default, retry lock attempts every 0.1 seconds for up to 5 seconds
+DISK_CACHE_LOCK_MAX_WAIT = float(getenv("DISK_CACHE_LOCK_MAX_WAIT", 5))
+DISK_CACHE_LOCK_INTERVAL = float(getenv("DISK_CACHE_LOCK_INTERVAL", 0.1))
+DEFAULT_CACHE_AGE = int(getenv("DEFAULT_CACHE_AGE", 7))
 
 # Specify 0 for cache age days to keep forever; not recommended for obvious reasons
 UNLIMITED_CACHE_AGE = 0
-DEFAULT_CACHE_AGE = 7
 
-_TOTAL_NUMCACHE_KEY = 'total_number_of_cache_to_disks'
+_TOTAL_NUMCACHE_KEY = "total_number_of_cache_to_disks"
 
 # Run-time cache data, stolen from Python functools.lru_cache implementation
 # Events resulting in nocache are cache misses that complete, but instruct cache_to_disk to
 # not store the result. Useful, for example, in a function that makes a network request and
 # experiences a failure that is considered likely to be temporary. This is accomplished in
 # the user function by raising NoCacheCondition
-_CacheInfo = namedtuple('CacheInfo', ['hits', 'misses', 'nocache'])
+_CacheInfo = namedtuple("_CacheInfo", ["hits", "misses", "nocache"])
 
 # This is probably unnecessary ...
 # logger.debug('cache_to_disk package loaded; using DISK_CACHE_DIR=%s',
@@ -112,73 +131,113 @@ class NoCacheCondition(Exception):
 
         return response
     """
-    __slots__ = ['function_value']
 
-    def __init__(self, function_value=None):
+    __slots__ = ["function_value"]
+
+    def __init__(self, function_value: Any = None):
         self.function_value = function_value
-        logger.info('NoCacheCondition caught in cache_to_disk')
+        logger.info("NoCacheCondition caught in cache_to_disk")
 
 
-def write_cache_file(cache_metadata_dict):
+class LockTimeout(Exception):
+    """Failed to acquire a lock after retrying to exhaustion"""
+
+
+@contextmanager
+def open_locked(path: str, mode: str, flags: int):
+    """You can use this directly, or you can use the open_exclusive() or open_shared() wrappers"""
+    with open("{}.lock".format(path), mode="w") as lockfd:
+        elapsed = 0
+        while elapsed < DISK_CACHE_LOCK_MAX_WAIT:
+            try:
+                fcntl.flock(lockfd, flags)
+                try:
+                    fd = open(path, mode=mode)
+                except IOError:
+                    # Close to release the lock and raise the exception
+                    # Some callers need to know about ENOENT, EPERM, etc.
+                    lockfd.close()
+                    raise
+                yield fd
+                fd.close()
+                lockfd.close()
+                break
+            except BlockingIOError:
+                logger.warning("Unable to get exclusive (write) lock on %s, retry in %s seconds ...", path, DISK_CACHE_LOCK_INTERVAL)
+                sleep(DISK_CACHE_LOCK_INTERVAL)
+        else:
+            raise LockTimeout("Unable to acquire write lock on {}".format(path))
+    # Lock is implicitly released when fd is closed
+    return
+
+
+def open_exclusive(path: str, mode: str = "w"):
+    """Non-blocking exclusive lock"""
+    return open_locked(path, mode, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+
+def open_shared(path: str, mode='r'):
+    """Non-blocking shared lock"""
+    return open_locked(path, mode, fcntl.LOCK_SH | fcntl.LOCK_NB)
+
+
+def write_cache_file(cache_metadata_dict: Dict) -> None:
     """Dump an object as JSON to a file"""
-    with open(DISK_CACHE_FILE, 'w') as f:
+    with open_exclusive(DISK_CACHE_FILE) as f:
         return json.dump(cache_metadata_dict, f)
 
 
-def load_cache_metadata_json():
+def load_cache_metadata_json() -> Dict:
     """Load a JSON file, create it with empty cache structure if it doesn't exist"""
     try:
-        with open(DISK_CACHE_FILE, 'r') as f:
+        with open_shared(DISK_CACHE_FILE) as f:
             return json.load(f)
     except FileNotFoundError:
         write_cache_file({_TOTAL_NUMCACHE_KEY: 0})
         return {_TOTAL_NUMCACHE_KEY: 0}
 
 
-def ensure_dir(directory):
+def ensure_dir(directory: str) -> None:
     """Create a directory tree if it doesn't already exist"""
     if not file_exists(directory):
         os.makedirs(directory)
         write_cache_file({_TOTAL_NUMCACHE_KEY: 0})
 
 
-def pickle_big_data(data, file_path):
+def pickle_big_data(data: Any, file_path: str) -> None:
     """Write a pickled Python object to a file in chunks"""
     bytes_out = pickle.dumps(data, protocol=4)
-    with open(file_path, 'wb') as f_out:
+    with open_exclusive(file_path, "wb") as f_out:
         for idx in range(0, len(bytes_out), MAX_PICKLE_BYTES):
-            f_out.write(bytes_out[idx:idx + MAX_PICKLE_BYTES])
+            f_out.write(bytes_out[idx: idx + MAX_PICKLE_BYTES])
 
 
-def unpickle_big_data(file_path):
+def unpickle_big_data(file_path: str) -> Any:
     """Return a Python object from a file containing pickled data in chunks"""
     try:
-        with open(file_path, 'rb') as f:
+        with open_shared(file_path, "rb") as f:
             return pickle.load(f)
     except Exception:  # noqa, pylint: disable=broad-except
         bytes_in = bytearray(0)
         input_size = os.path.getsize(file_path)
-        with open(file_path, 'rb') as f_in:
+        with open_shared(file_path, mode="rb") as f_in:
             for _ in range(0, input_size, MAX_PICKLE_BYTES):
                 bytes_in += f_in.read(MAX_PICKLE_BYTES)
         return pickle.loads(bytes_in)
 
 
-def get_age_of_file(filename, unit='days'):
+def get_age_of_file(filename: str, unit: str = "days") -> int:
     """Return relative age of a file as a datetime.timedelta"""
-    age = (datetime.today() - datetime.fromtimestamp(getmtime(filename)))
+    age = datetime.today() - datetime.fromtimestamp(getmtime(filename))
     return getattr(age, unit)
 
 
-def get_files_in_directory(directory):
+def get_files_in_directory(directory: str) -> List[str]:
     """Return all files in a directory, non-recursive"""
-    return [
-        f for f in os.listdir(directory) if
-        isfile(join_path(directory, f))
-    ]
+    return [f for f in os.listdir(directory) if isfile(join_path(directory, f))]
 
 
-def delete_old_disk_caches():
+def delete_old_disk_caches() -> None:
     cache_metadata = load_cache_metadata_json()
     new_cache_metadata = deepcopy(cache_metadata)
     cache_changed = False
@@ -187,15 +246,17 @@ def delete_old_disk_caches():
             continue
         to_keep = []
         for function_cache in function_caches:
-            max_age_days = int(function_cache['max_age_days'])
-            file_name = join_path(DISK_CACHE_DIR, function_cache['file_name'])
+            max_age_days = int(function_cache["max_age_days"])
+            file_name = join_path(DISK_CACHE_DIR, function_cache["file_name"])
             if not file_exists(file_name):
                 cache_changed = True
                 continue
             if not get_age_of_file(file_name) > max_age_days != UNLIMITED_CACHE_AGE:
                 to_keep.append(function_cache)
                 continue
-            logger.info('Removing stale cache file %s, > %d days', file_name, max_age_days)
+            logger.info(
+                "Removing stale cache file %s, > %d days", file_name, max_age_days
+            )
             cache_changed = True
             os.remove(file_name)
         if to_keep:
@@ -204,19 +265,19 @@ def delete_old_disk_caches():
         write_cache_file(new_cache_metadata)
 
 
-def get_disk_cache_for_function(function_name):
+def get_disk_cache_for_function(function_name: str) -> Optional[Dict]:
     cache_metadata = load_cache_metadata_json()
     return cache_metadata.get(function_name, None)
 
 
-def get_disk_cache_size_for_function(function_name):
+def get_disk_cache_size_for_function(function_name: str) -> Optional[int]:
     """Return the current number of entries in the cache for a function by name"""
     function_cache = get_disk_cache_for_function(function_name)
     return None if function_cache is None else len(function_cache)
 
 
-def delete_disk_caches_for_function(function_name):
-    logger.debug('Removing cache entries for %s', function_name)
+def delete_disk_caches_for_function(function_name: str) -> None:
+    logger.debug("Removing cache entries for %s", function_name)
     n_deleted = 0
     cache_metadata = load_cache_metadata_json()
     if function_name not in cache_metadata:
@@ -224,23 +285,26 @@ def delete_disk_caches_for_function(function_name):
 
     functions_to_delete_cache_for = cache_metadata.pop(function_name)
     for function_cache in functions_to_delete_cache_for:
-        file_name = join_path(DISK_CACHE_DIR, function_cache['file_name'])
+        file_name = join_path(DISK_CACHE_DIR, function_cache["file_name"])
         os.remove(file_name)
         n_deleted += 1
-    logger.debug('Removed %s cache entries for %s', n_deleted, function_name)
+    logger.debug("Removed %s cache entries for %s", n_deleted, function_name)
     write_cache_file(cache_metadata)
 
 
-def cache_exists(cache_metadata, function_name, *args, **kwargs):
+def cache_exists(
+    cache_metadata: Dict, function_name: str, *args, **kwargs
+) -> Tuple[bool, Any]:
     if function_name not in cache_metadata:
         return False, None
     new_caches_for_function = []
     cache_changed = False
     for function_cache in cache_metadata[function_name]:
-        if function_cache['args'] == str(args) and (
-                function_cache['kwargs'] == str(kwargs)):
-            max_age_days = int(function_cache['max_age_days'])
-            file_name = join_path(DISK_CACHE_DIR, function_cache['file_name'])
+        if function_cache["args"] == str(args) and (
+            function_cache["kwargs"] == str(kwargs)
+        ):
+            max_age_days = int(function_cache["max_age_days"])
+            file_name = join_path(DISK_CACHE_DIR, function_cache["file_name"])
             if file_exists(file_name):
                 if get_age_of_file(file_name) > max_age_days != UNLIMITED_CACHE_AGE:
                     os.remove(file_name)
@@ -262,22 +326,22 @@ def cache_exists(cache_metadata, function_name, *args, **kwargs):
 
 
 def cache_function_value(
-        function_value,
-        n_days_to_cache,
-        cache_metadata,
-        function_name,
-        *args,
-        **kwargs):
+    function_value: Any,
+    n_days_to_cache: int,
+    cache_metadata: Any,
+    function_name: str,
+    *args,
+    **kwargs,
+) -> None:
     if function_name == _TOTAL_NUMCACHE_KEY:
-        raise Exception(
-            'Cant cache function named %s' % _TOTAL_NUMCACHE_KEY)
+        raise Exception("Cant cache function named %s" % _TOTAL_NUMCACHE_KEY)
     function_caches = cache_metadata.get(function_name, [])
-    new_file_name = str(int(cache_metadata[_TOTAL_NUMCACHE_KEY]) + 1) + '.pkl'
+    new_file_name = str(int(cache_metadata[_TOTAL_NUMCACHE_KEY]) + 1) + ".pkl"
     new_cache = {
-        'args': str(args),
-        'kwargs': str(kwargs),
-        'file_name': new_file_name,
-        'max_age_days': n_days_to_cache
+        "args": str(args),
+        "kwargs": str(kwargs),
+        "file_name": new_file_name,
+        "max_age_days": n_days_to_cache,
     }
     pickle_big_data(function_value, join_path(DISK_CACHE_DIR, new_file_name))
     function_caches.append(new_cache)
@@ -286,84 +350,110 @@ def cache_function_value(
     write_cache_file(cache_metadata)
 
 
-def cache_to_disk(n_days_to_cache=DEFAULT_CACHE_AGE):
+# F = TypeVar("F", bound=Callable[..., Any])
+
+
+def cache_to_disk(n_days_to_cache: int = DEFAULT_CACHE_AGE) -> Callable:
     """Cache to disk"""
     if n_days_to_cache == UNLIMITED_CACHE_AGE:
-        warnings.warn('Using an unlimited age cache is not recommended', stacklevel=3)
+        warnings.warn("Using an unlimited age cache is not recommended", stacklevel=3)
     if isinstance(n_days_to_cache, int):
         if n_days_to_cache < 0:
             n_days_to_cache = 0
     elif n_days_to_cache is not None:
-        raise TypeError('Expected n_days_to_cache to be an integer or None')
+        raise TypeError("Expected n_days_to_cache to be an integer or None")
 
-    def decorating_function(original_function):
+    def decorating_function(original_function: Callable) -> Callable:
         wrapper = _cache_to_disk_wrapper(original_function, n_days_to_cache, _CacheInfo)
         return wrapper
 
     return decorating_function
 
 
-def _cache_to_disk_wrapper(original_func, n_days_to_cache, _CacheInfo):  # noqa, pylint: disable=invalid-name
+def _cache_to_disk_wrapper(
+    original_func: Callable, n_days_to_cache: int, _CacheInfo: type
+) -> Callable:  # pylint: disable=invalid-name
     hits = misses = nocache = 0
 
-    def wrapper(*args, **kwargs):
+    def wrapper(*args, **kwargs) -> Any:
         nonlocal hits, misses, nocache
         cache_metadata = load_cache_metadata_json()
         already_cached, function_value = cache_exists(
-            cache_metadata, original_func.__name__, *args, **kwargs)
+            cache_metadata, original_func.__name__, *args, **kwargs
+        )
         if already_cached:
-            logger.debug('Cache HIT on %s (hits=%s, misses=%s, nocache=%s)',
-                         original_func.__name__, hits, misses, nocache)
+            logger.debug(
+                "Cache HIT on %s (hits=%s, misses=%s, nocache=%s)",
+                original_func.__name__,
+                hits,
+                misses,
+                nocache,
+            )
             hits += 1
             return function_value
 
-        logger.debug('Cache MISS on %s (hits=%s, misses=%s, nocache=%s)',
-                     original_func.__name__, hits, misses, nocache)
-        logger.debug(' -- MISS ARGS:    (%s)', ','.join(
-            [str(arg) for arg in args]))
-        logger.debug(' -- MISS KWARGS:  (%s)', ','.join(
-            ['{}={}'.format(str(k), str(v)) for k, v in kwargs.items()]))
+        logger.debug(
+            "Cache MISS on %s (hits=%s, misses=%s, nocache=%s)",
+            original_func.__name__,
+            hits,
+            misses,
+            nocache,
+        )
+        logger.debug(" -- MISS ARGS:    (%s)", ",".join([str(arg) for arg in args]))
+        logger.debug(
+            " -- MISS KWARGS:  (%s)",
+            ",".join(["{}={}".format(str(k), str(v)) for k, v in kwargs.items()]),
+        )
         misses += 1
 
         try:
             function_value = original_func(*args, **kwargs)
         except NoCacheCondition as err:
             nocache += 1
-            logger.debug('%s() threw NoCacheCondition exception; no new cache entry', original_func.__name__)
+            logger.debug(
+                "%s() threw NoCacheCondition exception; no new cache entry",
+                original_func.__name__,
+            )
             function_value = err.function_value
         else:
-            logger.debug('%s() returned, adding cache entry', original_func.__name__)
+            logger.debug("%s() returned, adding cache entry", original_func.__name__)
             cache_function_value(
                 function_value,
                 n_days_to_cache,
                 cache_metadata,
                 original_func.__name__,
                 *args,
-                **kwargs)
+                **kwargs,
+            )
         return function_value
 
-    def cache_info():
+    def cache_info() -> Type:
         """Report runtime cache statistics"""
         return _CacheInfo(hits, misses, nocache)
 
-    def cache_clear():
+    def cache_clear() -> None:
         """Clear the cache permanently from disk for this function"""
-        logger.info('Cache clear requested for %s(); %s items in cache ...', original_func.__name__, )
+        logger.info(
+            "Cache clear requested for %s(); %s items in cache ...",
+            original_func.__name__,
+        )
         delete_disk_caches_for_function(original_func.__name__)
 
-    def cache_size():
+    def cache_size() -> Optional[int]:
         """Return the number of cached entries for this function"""
         return get_disk_cache_size_for_function(original_func.__name__)
 
-    def cache_get_raw():
+    def cache_get_raw() -> Optional[Any]:
         """Return the raw cache object for this function as a list of dicts"""
-        warnings.warn('This is an internal interface and should not be used lightly', stacklevel=3)
+        warnings.warn(
+            "This is an internal interface and should not be used lightly", stacklevel=3
+        )
         return get_disk_cache_for_function(original_func.__name__)
 
-    wrapper.cache_info = cache_info
-    wrapper.cache_clear = cache_clear
-    wrapper.cache_size = cache_size
-    wrapper.cache_get_raw = cache_get_raw
+    wrapper.cache_info = cache_info  # type: ignore
+    wrapper.cache_clear = cache_clear  # type: ignore
+    wrapper.cache_size = cache_size  # type: ignore
+    wrapper.cache_get_raw = cache_get_raw  # type: ignore
     return wrapper
 
 


### PR DESCRIPTION
This is not well tested and is probably not suitable for merge, but I plan to use this branch a little while in my own project

_In theory_ it should only add new behavior for those who are using cache_to_disk in a (probably) uncommon way. Please see #10 for background

From limited testing, it seems that it's a relatively rare case (<1% of the time) that the lock can't be acquired on the first try. I've not yet encountered a case where the retries were exhausted. In that case (exhausting retries) an exception will be raised. This would probably have to be documented before even being considered for a merge into your project